### PR TITLE
readme: use official action instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # GitHub App installation access token generator
 
+## :warning: Use the official action from GitHub here: https://github.com/actions/create-github-app-token
+
+
+
 GitHub Action that can be used to generate an installation access token for a GitHub App. This token can for instance be used to clone repos, given the GitHub App has sufficient permissions to do so.
 
 ## Usage


### PR DESCRIPTION
Added a warning to use the official GitHub action for token generation.